### PR TITLE
Renamed plugin's class to make it unique

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const defaultDefinitions = require('./defaults/definitions');
 
 const dashboards = require('./dashboards')
 
-class Plugin {
+class AlertsPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
@@ -301,4 +301,4 @@ class Plugin {
   }
 }
 
-module.exports = Plugin;
+module.exports = AlertsPlugin;


### PR DESCRIPTION
## What did you implement:

<!--
Briefly describe the feature if no issue exists for this PR
-->

Renamed plugin's class to make it unique since serverless framework has a check that prevents duplicated plugins from loading. Unfortunately, this check is done using class names, thus there is a high chance that this plugin would overlap with another one.

https://github.com/serverless/serverless/blob/master/lib/classes/PluginManager.js#L70

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

Changed class name from `Plugin` to `AlertsPlugin`

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Provide verification config/commands/resources

