### PR TITLE
add stackNamePrefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ custom:
     dashboards: true # Experimental
 
     nameTemplate: $[functionName]-$[metricName]-Alarm # Optionally - naming template for alarms, can be overwritten in definitions
+    stackNamePrefix: false # Optionally - whether to prefix alarm names with the stack name, default is `true`
 
     topics:
       ok: ${self:service}-${opt:stage}-alerts-ok
@@ -123,12 +124,13 @@ custom:
 
 ## Custom Naming
 You can define custom naming template for the alarms. `nameTemplate` property under `alerts` configures naming template for all the alarms, while placing `nameTemplate` under alarm definition configures (overwrites) it for that specific alarm only. Naming template provides interpolation capabilities, where supported placeholders are:
+  - `$[stackName]` - stack name (e.g. `fooservice-dev`)
   - `$[functionName]` - function name (e.g. `helloWorld`)
   - `$[functionId]` - function logical id (e.g. `HelloWorldLambdaFunction`)
   - `$[metricName]` - metric name (e.g. `Duration`)
   - `$[metricId]` - metric id (e.g. `BunyanErrorsHelloWorldLambdaFunction` for the log based alarms, `$[metricName]` otherwise)
 
-> Note: All the alarm names are prefixed with stack name (e.g. `fooservice-dev`).
+Alarm names are prefixed with stack name (e.g. `fooservice-dev`) unless `nameTemplate` contains `$[stackName]`, or the `stackNamePrefix` option is `false`.
 
 ## Default Definitions
 The plugin provides some default definitions that you can simply drop into your application. For example:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-aws-alerts",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -128,6 +128,7 @@ class AlertsPlugin {
 
     if (definition.nameTemplate) {
       alarm.Properties.AlarmName = this.naming.getAlarmName({
+        stackNamePrefix: definition.stackNamePrefix,
         template: definition.nameTemplate,
         functionLogicalId: functionRef,
         metricName: definition.metric,
@@ -243,7 +244,9 @@ class AlertsPlugin {
       const normalizedFunctionName = this.providerNaming.getLambdaLogicalId(functionName);
 
       const functionAlarms = this.getFunctionAlarms(functionObj, config, definitions);
-      const alarms = globalAlarms.concat(functionAlarms).map(alarm => _.assign({ nameTemplate: config.nameTemplate }, alarm));
+
+      const alarms = globalAlarms.concat(functionAlarms).map(alarm =>
+        _.assign({ nameTemplate: config.nameTemplate, stackNamePrefix: config.stackNamePrefix }, alarm));
 
       const alarmStatements = alarms.reduce((statements, alarm) => {
         const key = this.naming.getAlarmCloudFormationRef(alarm.name, functionName);

--- a/src/naming.js
+++ b/src/naming.js
@@ -25,12 +25,15 @@ class Naming {
 
   getAlarmName(options) {
     const interpolatedTemplate = options.template
+      .replace('$[stackName]', options.stackName)
       .replace('$[functionName]', options.functionName)
       .replace('$[functionId]', options.functionLogicalId)
       .replace('$[metricName]', options.metricName)
       .replace('$[metricId]', options.metricId);
 
-    return `${options.stackName}-${interpolatedTemplate}`;
+    const prefix = (options.template.includes('$[stackName]') || options.stackNamePrefix === false) ? '' : `${options.stackName}-`;
+
+    return `${prefix}${interpolatedTemplate}`;
   }
 }
 

--- a/src/naming.test.js
+++ b/src/naming.test.js
@@ -40,16 +40,31 @@ describe('#naming', function () {
     let naming = null;
     beforeEach(() => naming = new Naming());
 
-    it('should interpolate alarm name', () => {
-      const template = '$[functionName]-$[functionId]-$[metricName]-$[metricId]';
+    [true, false, undefined].forEach(stackNamePrefix => {
+      const prefixDescription = stackNamePrefix === false ? '' : 'and prefix with stack name';
+      it(`should interpolate alarm name ${prefixDescription}`, () => {
+        const template = '$[functionName]-$[functionId]-$[metricName]-$[metricId]';
+        const functionName = 'function';
+        const functionLogicalId = 'functionId';
+        const metricName = 'metric';
+        const metricId = 'metricId';
+        const stackName = 'fooservice-dev';
+        const expectedPrefix = stackNamePrefix === false ? '' : `${stackName}-`;
+
+        const expected = `${expectedPrefix}${functionName}-${functionLogicalId}-${metricName}-${metricId}`;
+        const actual = naming.getAlarmName({ stackNamePrefix, template, functionName, functionLogicalId, metricName, metricId, stackName });
+
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    it('should not prefix when $[stackName] is in the template', () => {
+      const template = '$[functionName]-$[stackName]';
       const functionName = 'function';
-      const functionLogicalId = 'functionId';
-      const metricName = 'metric';
-      const metricId = 'metricId';
       const stackName = 'fooservice-dev';
 
-      const expected = `${stackName}-${functionName}-${functionLogicalId}-${metricName}-${metricId}`;
-      const actual = naming.getAlarmName({ template, functionName, functionLogicalId, metricName, metricId, stackName });
+      const expected = `${functionName}-${stackName}`;
+      const actual = naming.getAlarmName({ template, functionName, stackName });
 
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
* Adds an optional config option `stackNamePrefix` (defaults to `true`). When true, use existing behavior which is to prefix alarms names with `${stackName}-`. When set to false, disables automatic alarm name prefixing.

* Adds `$[stackName]` as a variable for interpolation in the alarm name template specified in the `nameTemplate` option.
